### PR TITLE
feat: fake executor

### DIFF
--- a/crates/remora/src/executor/api.rs
+++ b/crates/remora/src/executor/api.rs
@@ -10,7 +10,6 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffectsAPI,
     object::Object,
-    storage::BackingStore,
     transaction::InputObjectKind,
 };
 
@@ -95,7 +94,11 @@ impl<U: TransactionEffectsAPI + Clone + Debug> ExecutionResultsAndEffects<U> {
     }
 }
 
-pub trait StateStore<U>: BackingStore {
+pub trait StateStore<U> {
+    fn read_object(
+        &self,
+        id: &ObjectID,
+    ) -> Result<Option<Object>, sui_types::storage::error::Error>;
     /// Commit the objects to the store.
     fn commit_objects(&self, updates: U, new_state: BTreeMap<ObjectID, Object>);
 }

--- a/crates/remora/src/executor/api.rs
+++ b/crates/remora/src/executor/api.rs
@@ -4,7 +4,6 @@
 use std::{collections::BTreeMap, fmt::Debug, future::Future, ops::Deref, sync::Arc};
 
 use serde::{Deserialize, Serialize};
-use sui_single_node_benchmark::benchmark_context::BenchmarkContext;
 use sui_types::{
     base_types::{ObjectID, SequenceNumber},
     digests::TransactionDigest,
@@ -111,20 +110,22 @@ pub trait Executor {
     type ExecutionResults: Clone + TransactionEffectsAPI + Debug;
     /// The type of store to store objects.
     type Store: StateStore<Self::ExecutionResults>;
+    /// The benchmark context.
+    type ExecutionContext;
 
     /// Get the context for the benchmark.
-    fn context(&self) -> Arc<BenchmarkContext>;
+    fn context(&self) -> Arc<Self::ExecutionContext>;
 
     /// Execute a transaction and return the results.
     fn execute(
-        ctx: Arc<BenchmarkContext>,
+        ctx: Arc<Self::ExecutionContext>,
         store: Arc<Self::Store>,
         transaction: &TransactionWithTimestamp<Self::Transaction>,
     ) -> impl Future<Output = ExecutionResultsAndEffects<Self::ExecutionResults>> + Send;
 
     /// Check version ID check prior to execution
     fn pre_execute_check(
-        ctx: Arc<BenchmarkContext>,
+        ctx: Arc<Self::ExecutionContext>,
         store: Arc<Self::Store>,
         transaction: &TransactionWithTimestamp<Self::Transaction>,
     ) -> bool;

--- a/crates/remora/src/executor/fake.rs
+++ b/crates/remora/src/executor/fake.rs
@@ -1,0 +1,243 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::BTreeMap,
+    future::Future,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use sui_single_node_benchmark::benchmark_context::BenchmarkContext;
+use sui_types::{
+    base_types::{ObjectID, ObjectRef, SequenceNumber},
+    committee::EpochId,
+    digests::{TransactionDigest, TransactionEventsDigest},
+    effects::{InputSharedObject, ObjectChange, TransactionEffectsAPI},
+    execution_status::ExecutionStatus,
+    gas::GasCostSummary,
+    object::{Object, Owner},
+    transaction::InputObjectKind,
+};
+
+use super::api::{
+    ExecutableTransaction,
+    ExecutionResultsAndEffects,
+    Executor,
+    StateStore,
+    TransactionWithTimestamp,
+};
+
+#[derive(Clone)]
+pub struct FakeTransaction {
+    pub digest: TransactionDigest,
+    inputs: Vec<InputObjectKind>,
+}
+
+impl ExecutableTransaction for FakeTransaction {
+    fn digest(&self) -> &TransactionDigest {
+        &self.digest
+    }
+
+    fn input_objects(&self) -> Vec<InputObjectKind> {
+        self.inputs.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FakeTransactionEffects {
+    transaction_digest: TransactionDigest,
+    modified_at_versions: Vec<(ObjectID, SequenceNumber)>,
+}
+
+impl TransactionEffectsAPI for FakeTransactionEffects {
+    fn status(&self) -> &ExecutionStatus {
+        &ExecutionStatus::Success
+    }
+
+    fn into_status(self) -> ExecutionStatus {
+        unreachable!()
+    }
+
+    fn executed_epoch(&self) -> EpochId {
+        unreachable!()
+    }
+
+    fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)> {
+        self.modified_at_versions.clone()
+    }
+
+    fn lamport_version(&self) -> SequenceNumber {
+        unreachable!()
+    }
+
+    fn old_object_metadata(&self) -> Vec<(ObjectRef, Owner)> {
+        unreachable!()
+    }
+
+    fn input_shared_objects(&self) -> Vec<InputSharedObject> {
+        unreachable!()
+    }
+
+    fn created(&self) -> Vec<(ObjectRef, Owner)> {
+        unreachable!()
+    }
+
+    fn mutated(&self) -> Vec<(ObjectRef, Owner)> {
+        unreachable!()
+    }
+
+    fn unwrapped(&self) -> Vec<(ObjectRef, Owner)> {
+        unreachable!()
+    }
+
+    fn deleted(&self) -> Vec<ObjectRef> {
+        unreachable!()
+    }
+
+    fn unwrapped_then_deleted(&self) -> Vec<ObjectRef> {
+        unreachable!()
+    }
+
+    fn wrapped(&self) -> Vec<ObjectRef> {
+        unreachable!()
+    }
+
+    fn object_changes(&self) -> Vec<ObjectChange> {
+        unreachable!()
+    }
+
+    fn gas_object(&self) -> (ObjectRef, Owner) {
+        unreachable!()
+    }
+
+    fn events_digest(&self) -> Option<&TransactionEventsDigest> {
+        unreachable!()
+    }
+
+    fn dependencies(&self) -> &[TransactionDigest] {
+        unreachable!()
+    }
+
+    fn transaction_digest(&self) -> &TransactionDigest {
+        &self.transaction_digest
+    }
+
+    fn gas_cost_summary(&self) -> &GasCostSummary {
+        unreachable!()
+    }
+
+    fn status_mut_for_testing(&mut self) -> &mut ExecutionStatus {
+        unreachable!()
+    }
+
+    fn gas_cost_summary_mut_for_testing(&mut self) -> &mut GasCostSummary {
+        unreachable!()
+    }
+
+    fn transaction_digest_mut_for_testing(&mut self) -> &mut TransactionDigest {
+        unreachable!()
+    }
+
+    fn dependencies_mut_for_testing(&mut self) -> &mut Vec<TransactionDigest> {
+        unreachable!()
+    }
+
+    fn unsafe_add_input_shared_object_for_testing(&mut self, _kind: InputSharedObject) {
+        unreachable!()
+    }
+
+    fn unsafe_add_deleted_live_object_for_testing(&mut self, _obj_ref: ObjectRef) {
+        unreachable!()
+    }
+
+    fn unsafe_add_object_tombstone_for_testing(&mut self, _obj_ref: ObjectRef) {
+        unreachable!()
+    }
+}
+
+pub struct FakeObjectStore {
+    objects: Arc<RwLock<BTreeMap<ObjectID, Object>>>,
+}
+
+impl<FakeTransactionEffects> StateStore<FakeTransactionEffects> for FakeObjectStore {
+    fn commit_objects(
+        &self,
+        _updates: FakeTransactionEffects,
+        new_state: BTreeMap<ObjectID, Object>,
+    ) {
+        let mut objects = self.objects.write().unwrap();
+        for (object_id, object) in new_state {
+            objects.insert(object_id, object);
+        }
+    }
+
+    fn read_object(
+        &self,
+        id: &ObjectID,
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
+        let objects = self.objects.read().unwrap();
+        Ok(objects.get(id).cloned())
+    }
+}
+
+pub struct FakeExecutor {
+    // TODO: Unused, this should be removed by either making the benchmark context generic or
+    // changing the Executor trait structure.
+    benchmark_context: Arc<BenchmarkContext>,
+    /// The duration of the transaction execution (in number of spins).
+    execution_duration: u64,
+    /// The duration of the checks that are done before executing the transaction (in number of spins).
+    checks_duration: u64,
+}
+
+impl FakeExecutor {
+    pub fn new(
+        benchmark_context: BenchmarkContext,
+        execution_duration: Duration,
+        checks_duration: Duration,
+    ) -> Self {
+        Self {
+            benchmark_context: Arc::new(benchmark_context),
+            execution_duration: Self::calibrate(execution_duration),
+            checks_duration: Self::calibrate(checks_duration),
+        }
+    }
+
+    fn calibrate(duration: Duration) -> u64 {
+        // https://gist.github.com/Scofield626/48bc1926dbd22a197573d9d7b0142ff6
+        todo!()
+    }
+}
+
+impl Executor for FakeExecutor {
+    type Transaction = FakeTransaction;
+
+    type ExecutionResults = FakeTransactionEffects;
+
+    type Store = FakeObjectStore;
+
+    fn context(&self) -> Arc<BenchmarkContext> {
+        self.benchmark_context.clone()
+    }
+
+    fn execute(
+        _ctx: Arc<BenchmarkContext>,
+        _store: Arc<Self::Store>,
+        _transaction: &TransactionWithTimestamp<Self::Transaction>,
+    ) -> impl Future<Output = ExecutionResultsAndEffects<Self::ExecutionResults>> + Send {
+        // for _ in 0..self.execution_duration {
+        //     std::hint::spin_loop();
+        // }
+
+        async move { todo!() }
+    }
+
+    fn pre_execute_check(
+        ctx: Arc<BenchmarkContext>,
+        store: Arc<Self::Store>,
+        transaction: &TransactionWithTimestamp<Self::Transaction>,
+    ) -> bool {
+        todo!()
+    }
+}

--- a/crates/remora/src/executor/fake.rs
+++ b/crates/remora/src/executor/fake.rs
@@ -242,7 +242,7 @@ impl FakeExecutionContext {
 
     /// Calibrate the fake executor to run for the target_duration
     fn calibrate(target_duration: Duration) -> u64 {
-        let mut iterations = 10_00_000;
+        let mut iterations = 1_000_000;
         let mut step_size = iterations;
 
         loop {

--- a/crates/remora/src/executor/mod.rs
+++ b/crates/remora/src/executor/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod api;
 pub mod dependency_controller;
+pub mod fake;
 pub mod sui;

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -3,18 +3,22 @@
 
 use std::{
     collections::{BTreeMap, HashSet},
+    fs,
+    io::{BufReader, Read},
     ops::Deref,
+    path::PathBuf,
     sync::Arc,
 };
 
 use sui_single_node_benchmark::{
     benchmark_context::BenchmarkContext,
     command::{Component, WorkloadKind},
+    mock_account::Account,
     mock_storage::InMemoryObjectStore,
     workload::Workload,
 };
 use sui_types::{
-    base_types::ObjectID,
+    base_types::{ObjectID, SuiAddress},
     digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI},
     executable_transaction::VerifiedExecutableTransaction,
@@ -108,15 +112,6 @@ pub async fn generate_transactions(config: &BenchmarkParameters) -> Vec<Certifie
 
     transactions
 }
-
-use std::{
-    fs,
-    io::{BufReader, Read},
-    path::PathBuf,
-};
-
-use sui_single_node_benchmark::mock_account::Account;
-use sui_types::base_types::SuiAddress;
 
 pub fn export_to_files(
     accounts: &BTreeMap<SuiAddress, Account>,
@@ -270,6 +265,7 @@ impl Executor for SuiExecutor {
     type Transaction = CertifiedTransaction;
     type ExecutionResults = TransactionEffects;
     type Store = InMemoryObjectStore;
+    type ExecutionContext = BenchmarkContext;
 
     fn context(&self) -> Arc<BenchmarkContext> {
         self.ctx.clone()

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -19,6 +19,7 @@ use sui_types::{
     effects::{TransactionEffects, TransactionEffectsAPI},
     executable_transaction::VerifiedExecutableTransaction,
     object::Object,
+    storage::ObjectStore,
     transaction::{CertifiedTransaction, InputObjectKind, TransactionDataAPI, VerifiedCertificate},
 };
 use tokio::time::Instant;
@@ -48,6 +49,13 @@ impl ExecutableTransaction for CertifiedTransaction {
 impl StateStore<TransactionEffects> for InMemoryObjectStore {
     fn commit_objects(&self, updates: TransactionEffects, new_state: BTreeMap<ObjectID, Object>) {
         self.commit_effects(updates, new_state);
+    }
+
+    fn read_object(
+        &self,
+        id: &ObjectID,
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
+        self.get_object(id)
     }
 }
 

--- a/crates/remora/src/primary/core.rs
+++ b/crates/remora/src/primary/core.rs
@@ -7,7 +7,6 @@ use dashmap::DashMap;
 use sui_types::{
     base_types::{ObjectID, ObjectRef},
     digests::TransactionDigest,
-    storage::ObjectStore,
 };
 use tokio::{
     sync::mpsc::{Receiver, Sender},
@@ -18,7 +17,12 @@ use super::mock_consensus::ConsensusCommit;
 use crate::{
     error::{NodeError, NodeResult},
     executor::api::{
-        ExecutableTransaction, ExecutionResults, Executor, StateStore, Store, Transaction,
+        ExecutableTransaction,
+        ExecutionResults,
+        Executor,
+        StateStore,
+        Store,
+        Transaction,
     },
 };
 
@@ -64,7 +68,7 @@ impl<E: Executor> PrimaryCore<E> {
             .iter()
             .map(|kind| {
                 self.store
-                    .get_object(&kind.object_id())
+                    .read_object(&kind.object_id())
                     .expect("Failed to read objects from store")
                     .map(|object| (object.id(), object.compute_object_reference()))
                     .expect("Input object not found") // TODO: Return error instead of panic

--- a/crates/remora/src/proxy/core.rs
+++ b/crates/remora/src/proxy/core.rs
@@ -76,6 +76,7 @@ impl<E: Executor> ProxyCore<E> {
         Store<E>: Send + Sync,
         Transaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
+        <E as Executor>::ExecutionContext: Send + Sync,
     {
         tracing::info!("Proxy {} started", self.id);
         match self.mode {
@@ -181,6 +182,7 @@ impl<E: Executor> ProxyCore<E> {
         Store<E>: Send + Sync,
         Transaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
+        <E as Executor>::ExecutionContext: Send + Sync,
     {
         tokio::spawn(async move { self.run().await })
     }
@@ -191,6 +193,7 @@ impl<E: Executor> ProxyCore<E> {
         Store<E>: Send + Sync,
         Transaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
+        <E as Executor>::ExecutionContext: Send + Sync,
     {
         let num_threads = num_cpus::get();
 


### PR DESCRIPTION
Refine https://github.com/Scofield626/sui/pull/1 by adding a fake executor with access to storage.

Remaining todos:

- [x] Generic BenchmarkContext
- [x] Use a fake benchmark context to propagate the execution and checking time
- [x] Calibrate the CPU spinning loop