### PR TITLE
Replace CertifiedTransaction

### DIFF
--- a/crates/remora/src/bin/load_generator.rs
+++ b/crates/remora/src/bin/load_generator.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Context};
 use clap::Parser;
 use remora::{
     config::{BenchmarkParameters, ImportExport, ValidatorConfig, WorkloadType},
-    executor::sui::{check_logs_for_shared_object, import_from_files},
+    //executor::sui::{check_logs_for_shared_object, import_from_files},
     load_generator::{default_metrics_address, LoadGenerator},
     metrics::Metrics,
 };
@@ -54,8 +54,9 @@ async fn main() -> anyhow::Result<()> {
             transactions = load_generator.initialize().await;
         }
         WorkloadType::SharedObjects { .. } => {
-            let log_dir = check_logs_for_shared_object(&benchmark_config).await;
-            (_, transactions) = import_from_files(log_dir);
+            todo!();
+            //let log_dir = check_logs_for_shared_object(&benchmark_config).await;
+            //(_, transactions) = import_from_files(log_dir);
         }
     };
 

--- a/crates/remora/src/executor/api.rs
+++ b/crates/remora/src/executor/api.rs
@@ -129,7 +129,7 @@ pub trait Executor: Clone {
 }
 
 /// Short for a transaction with a timestamp.
-pub type Transaction<E> = TransactionWithTimestamp<<E as Executor>::Transaction>;
+pub type RemoraTransaction<E> = TransactionWithTimestamp<<E as Executor>::Transaction>;
 
 /// Short for the results of executing a transaction.
 pub type ExecutionResults<E> = ExecutionResultsAndEffects<<E as Executor>::ExecutionResults>;

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -19,20 +19,24 @@ use sui_types::{
     effects::{TransactionEffects, TransactionEffectsAPI},
     executable_transaction::VerifiedExecutableTransaction,
     object::Object,
-    transaction::{CertifiedTransaction, InputObjectKind, TransactionDataAPI, VerifiedCertificate},
+    transaction::{
+        CertifiedTransaction, InputObjectKind, Transaction, TransactionDataAPI, VerifiedCertificate,
+    },
 };
 use tokio::time::Instant;
 
-use super::api::{ExecutableTransaction, ExecutionResults, Executor, StateStore, Transaction};
+use super::api::{
+    ExecutableTransaction, ExecutionResults, Executor, RemoraTransaction, StateStore,
+};
 use crate::config::{BenchmarkParameters, WorkloadType};
 
 /// Represents a Sui transaction.
-pub type SuiTransaction = Transaction<SuiExecutor>;
+pub type SuiTransaction = RemoraTransaction<SuiExecutor>;
 
 /// Represents the results of the execution of a Sui transaction.
 pub type SuiExecutionResults = ExecutionResults<SuiExecutor>;
 
-impl ExecutableTransaction for CertifiedTransaction {
+impl ExecutableTransaction for Transaction {
     fn digest(&self) -> &TransactionDigest {
         self.digest()
     }
@@ -86,14 +90,14 @@ pub fn init_workload(config: &BenchmarkParameters) -> Workload {
     Workload::new(pre_generation, workload_type)
 }
 
-pub async fn generate_transactions(config: &BenchmarkParameters) -> Vec<CertifiedTransaction> {
+pub async fn generate_transactions(config: &BenchmarkParameters) -> Vec<Transaction> {
     tracing::debug!("Generating all transactions...");
     let workload = init_workload(config);
     let mut ctx = BenchmarkContext::new(workload.clone(), Component::PipeTxsToChannel, false).await;
     let start_time = Instant::now();
     let tx_generator = workload.create_tx_generator(&mut ctx).await;
     let transactions = ctx.generate_transactions(tx_generator).await;
-    let transactions = ctx.certify_transactions(transactions, false).await;
+    //let transactions = ctx.certify_transactions(transactions, false).await;
     let elapsed = start_time.elapsed();
     tracing::debug!(
         "Generated {} txs in {} ms",
@@ -262,7 +266,7 @@ impl SuiExecutor {
 }
 
 impl Executor for SuiExecutor {
-    type Transaction = CertifiedTransaction;
+    type Transaction = Transaction;
     type ExecutionResults = TransactionEffects;
     type Store = InMemoryObjectStore;
 
@@ -285,8 +289,11 @@ impl Executor for SuiExecutor {
             .read_objects_for_execution(&**epoch_store, &transaction.key(), &input_objects)
             .unwrap();
 
+        let mut transaction = ctx
+            .certify_transactions(vec![transaction.deref().to_owned()], true)
+            .await;
         let executable = VerifiedExecutableTransaction::new_from_certificate(
-            VerifiedCertificate::new_unchecked(transaction.deref().clone()),
+            VerifiedCertificate::new_unchecked(transaction.pop().unwrap()),
         );
 
         let (gas_status, input_objects) = sui_transaction_checks::check_certificate_input(
@@ -343,10 +350,10 @@ impl Executor for SuiExecutor {
 #[cfg(test)]
 mod tests {
 
-    use std::{fs, sync::Arc};
+    use std::sync::Arc;
 
     use crate::{
-        config::{BenchmarkParameters, WorkloadType},
+        config::BenchmarkParameters,
         executor::{
             api::Executor,
             sui::{generate_transactions, SuiExecutor, SuiTransaction},
@@ -370,8 +377,11 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    /*#[tokio::test]
     async fn shared_object_test_with_imported_file() {
+        use std::fs;
+        use crate::config::WorkloadType;
+
         let config = BenchmarkParameters {
             workload: WorkloadType::SharedObjects { txs_per_counter: 2 },
             ..BenchmarkParameters::new_for_tests()
@@ -401,5 +411,5 @@ mod tests {
 
         // Clean up directory after the test finishes
         fs::remove_dir_all(&working_directory).expect("Failed to delete working directory");
-    }
+    }*/
 }

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -17,9 +17,7 @@ use sui_types::{
     digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI},
     object::Object,
-    transaction::{
-        CertifiedTransaction, CheckedInputObjects, InputObjectKind, Transaction, TransactionDataAPI,
-    },
+    transaction::{CheckedInputObjects, InputObjectKind, Transaction, TransactionDataAPI},
 };
 use tokio::time::Instant;
 
@@ -117,7 +115,7 @@ use sui_types::base_types::SuiAddress;
 
 pub fn export_to_files(
     accounts: &BTreeMap<SuiAddress, Account>,
-    txs: &Vec<CertifiedTransaction>,
+    txs: &Vec<Transaction>,
     working_directory: PathBuf,
 ) {
     let start_time: std::time::Instant = std::time::Instant::now();
@@ -136,7 +134,7 @@ pub fn export_to_files(
 
 pub fn import_from_files(
     working_directory: PathBuf,
-) -> (BTreeMap<SuiAddress, Account>, Vec<CertifiedTransaction>) {
+) -> (BTreeMap<SuiAddress, Account>, Vec<Transaction>) {
     let start_time: std::time::Instant = std::time::Instant::now();
     // Read the accounts file into a buffer
     let mut accounts_file = BufReader::new(
@@ -158,7 +156,7 @@ pub fn import_from_files(
 
     // Deserialize from buffers
     let accounts: BTreeMap<SuiAddress, Account> = bincode::deserialize(&accounts_buf).unwrap();
-    let txs: Vec<CertifiedTransaction> = bincode::deserialize(&txs_buf).unwrap();
+    let txs: Vec<Transaction> = bincode::deserialize(&txs_buf).unwrap();
 
     let elapsed = start_time.elapsed().as_millis() as f64;
     tracing::info!("Import took {} ms", elapsed,);
@@ -174,7 +172,6 @@ pub async fn pre_generate_txn_log(config: &BenchmarkParameters, log_path: &str) 
     let mut ctx = BenchmarkContext::new(workload.clone(), Component::PipeTxsToChannel, false).await;
     let tx_generator = workload.create_tx_generator(&mut ctx).await;
     let txs = ctx.generate_transactions(tx_generator).await;
-    let txs = ctx.certify_transactions(txs, false).await;
 
     export_to_files(ctx.get_accounts(), &txs, log_path.into());
     tracing::info!("Finish generating and exporting");
@@ -257,7 +254,7 @@ impl SuiExecutor {
             let (_, read_txs) = import_from_files(self.log_dir_path.clone().unwrap());
             self.ctx
                 .validator()
-                .assigned_shared_object_versions(&read_txs)
+                .assigned_shared_object_versions_on_transaction(&read_txs)
                 .await;
         }
     }
@@ -372,10 +369,10 @@ mod tests {
         }
     }
 
-    /*#[tokio::test]
+    #[tokio::test]
     async fn shared_object_test_with_imported_file() {
-        use std::fs;
         use crate::config::WorkloadType;
+        use std::fs;
 
         let config = BenchmarkParameters {
             workload: WorkloadType::SharedObjects { txs_per_counter: 2 },
@@ -394,7 +391,7 @@ mod tests {
         executor
             .context()
             .validator()
-            .assigned_shared_object_versions(&read_txs) // Important!!
+            .assigned_shared_object_versions_on_transaction(&read_txs) // Important!!
             .await;
 
         let ctx = executor.context();
@@ -406,5 +403,5 @@ mod tests {
 
         // Clean up directory after the test finishes
         fs::remove_dir_all(&working_directory).expect("Failed to delete working directory");
-    }*/
+    }
 }

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -3,7 +3,6 @@
 
 use std::{
     collections::{BTreeMap, HashSet},
-    ops::Deref,
     sync::Arc,
 };
 
@@ -17,10 +16,9 @@ use sui_types::{
     base_types::ObjectID,
     digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI},
-    executable_transaction::VerifiedExecutableTransaction,
     object::Object,
     transaction::{
-        CertifiedTransaction, InputObjectKind, Transaction, TransactionDataAPI, VerifiedCertificate,
+        CertifiedTransaction, CheckedInputObjects, InputObjectKind, Transaction, TransactionDataAPI,
     },
 };
 use tokio::time::Instant;
@@ -289,21 +287,18 @@ impl Executor for SuiExecutor {
             .read_objects_for_execution(&**epoch_store, &transaction.key(), &input_objects)
             .unwrap();
 
-        let mut transaction = ctx
-            .certify_transactions(vec![transaction.deref().to_owned()], true)
-            .await;
-        let executable = VerifiedExecutableTransaction::new_from_certificate(
-            VerifiedCertificate::new_unchecked(transaction.pop().unwrap()),
-        );
-
-        let (gas_status, input_objects) = sui_transaction_checks::check_certificate_input(
-            &executable,
-            objects,
+        let (kind, signer, gas) = transaction.transaction_data().execution_parts();
+        let gas_status = sui_transaction_checks::get_gas_status(
+            &objects,
+            &gas,
             protocol_config,
             reference_gas_price,
+            transaction.transaction_data(),
         )
         .unwrap();
-        let (kind, signer, gas) = executable.transaction_data().execution_parts();
+
+        let objects = CheckedInputObjects::new_with_checked_transaction_inputs(objects);
+
         let (inner_temp_store, _, effects, _) = validator
             .get_epoch_store()
             .executor()
@@ -315,12 +310,12 @@ impl Executor for SuiExecutor {
                 &HashSet::new(),
                 &epoch_store.epoch(),
                 0,
-                input_objects,
+                objects,
                 gas,
                 gas_status,
                 kind,
                 signer,
-                *executable.digest(),
+                *transaction.digest(),
             );
         debug_assert!(effects.status().is_ok());
 

--- a/crates/remora/src/load_generator.rs
+++ b/crates/remora/src/load_generator.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use sui_types::transaction::CertifiedTransaction;
+use sui_types::transaction::Transaction;
 use tokio::{
     sync::mpsc::{self, Sender},
     time::{interval, Instant, MissedTickBehavior},
@@ -44,14 +44,14 @@ impl LoadGenerator {
     }
 
     /// Initialize the load generator. This will generate all required genesis objects and all transactions upfront.
-    pub async fn initialize(&mut self) -> Vec<CertifiedTransaction> {
+    pub async fn initialize(&mut self) -> Vec<Transaction> {
         generate_transactions(&self.config).await
     }
 
     // Function to run the transaction submission at a specific load
     async fn submit_transactions(
         &mut self,
-        transactions: Vec<CertifiedTransaction>,
+        transactions: Vec<Transaction>,
         load: u64,
         precision: u64,
         burst_duration: Duration,
@@ -102,7 +102,7 @@ impl LoadGenerator {
         tx_transactions
     }
 
-    pub async fn run(&mut self, transactions: Vec<CertifiedTransaction>) {
+    pub async fn run(&mut self, transactions: Vec<Transaction>) {
         let tx_transactions = self.connect_and_spawn_network_client().await;
 
         let warm_up_load = 2_000;
@@ -126,7 +126,7 @@ impl LoadGenerator {
 
     async fn warm_up_and_real_run(
         &mut self,
-        transactions: Vec<CertifiedTransaction>,
+        transactions: Vec<Transaction>,
         warm_up_load: u64,
         sender: Sender<SuiTransaction>,
     ) {
@@ -167,11 +167,7 @@ impl LoadGenerator {
         self.real_run(remaining_transactions.to_vec(), sender).await;
     }
 
-    async fn real_run(
-        &mut self,
-        transactions: Vec<CertifiedTransaction>,
-        sender: Sender<SuiTransaction>,
-    ) {
+    async fn real_run(&mut self, transactions: Vec<Transaction>, sender: Sender<SuiTransaction>) {
         let real_load = self.config.load;
         tracing::info!("Starting real run at {} load...", real_load);
 

--- a/crates/remora/src/primary/core.rs
+++ b/crates/remora/src/primary/core.rs
@@ -18,8 +18,8 @@ use super::mock_consensus::ConsensusCommit;
 use crate::{
     error::{NodeError, NodeResult},
     executor::api::{
-        ExecutableTransaction, ExecutionResults, Executor, ExecutorIndex, StateStore, Store,
-        Transaction, TransactionWithTimestamp,
+        ExecutableTransaction, ExecutionResults, Executor, ExecutorIndex, RemoraTransaction,
+        StateStore, Store, TransactionWithTimestamp,
     },
 };
 
@@ -41,19 +41,19 @@ pub struct PrimaryCore<E: Executor> {
     /// The object store.
     store: Store<E>,
     /// The receiver for consensus commits.
-    rx_commits: Receiver<ConsensusCommit<Transaction<E>>>,
+    rx_commits: Receiver<ConsensusCommit<RemoraTransaction<E>>>,
     /// The receiver for proxy results.
     rx_proxies: Receiver<ExecutionResults<E>>,
     /// Output channel for the final results.
-    tx_output: Sender<(Transaction<E>, ExecutionResults<E>)>,
+    tx_output: Sender<(RemoraTransaction<E>, ExecutionResults<E>)>,
     /// The transactions sent out to proxies
     pending_txns: PendingTransactions<E>,
     /// The sender to load balancer.
-    tx_committed_txns: Sender<Transaction<E>>,
+    tx_committed_txns: Sender<RemoraTransaction<E>>,
     /// The sender to a local executor.
-    tx_executor_local: Sender<Transaction<E>>,
+    tx_executor_local: Sender<RemoraTransaction<E>>,
     /// The receiver to a local executor.
-    rx_executor_local: Receiver<Transaction<E>>,
+    rx_executor_local: Receiver<RemoraTransaction<E>>,
     /// The sender to sync updates to proxy via load-balancer.
     tx_states_sync: Sender<ExecutionResults<E>>,
 }
@@ -63,13 +63,13 @@ impl<E: Executor> PrimaryCore<E> {
     pub fn new(
         executor: E,
         store: Store<E>,
-        rx_commits: Receiver<ConsensusCommit<Transaction<E>>>,
+        rx_commits: Receiver<ConsensusCommit<RemoraTransaction<E>>>,
         rx_proxies: Receiver<ExecutionResults<E>>,
-        tx_output: Sender<(Transaction<E>, ExecutionResults<E>)>,
+        tx_output: Sender<(RemoraTransaction<E>, ExecutionResults<E>)>,
         pending_txns: PendingTransactions<E>,
-        tx_committed_txns: Sender<Transaction<E>>,
-        tx_executor_local: Sender<Transaction<E>>,
-        rx_executor_local: Receiver<Transaction<E>>,
+        tx_committed_txns: Sender<RemoraTransaction<E>>,
+        tx_executor_local: Sender<RemoraTransaction<E>>,
+        rx_executor_local: Receiver<RemoraTransaction<E>>,
         tx_states_sync: Sender<ExecutionResults<E>>,
     ) -> Self {
         Self {
@@ -153,7 +153,7 @@ impl<E: Executor> PrimaryCore<E> {
     where
         E: Send + 'static,
         Store<E>: Send + Sync,
-        Transaction<E>: Send + Sync,
+        RemoraTransaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
     {
         let ctx = self.executor.context();
@@ -188,7 +188,7 @@ impl<E: Executor> PrimaryCore<E> {
     where
         E: Send + 'static,
         Store<E>: Send + Sync,
-        Transaction<E>: Send + Sync,
+        RemoraTransaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
     {
         loop {
@@ -235,7 +235,7 @@ impl<E: Executor> PrimaryCore<E> {
     where
         E: Send + 'static,
         Store<E>: Send + Sync,
-        Transaction<E>: Send + Sync,
+        RemoraTransaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
     {
         tokio::spawn(async move { self.run().await })

--- a/crates/remora/src/primary/load_balancer.rs
+++ b/crates/remora/src/primary/load_balancer.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{NodeError, NodeResult},
     executor::api::{
         ExecutableTransaction, ExecutionResults, Executor, ExecutorIndex, NewStates,
-        PrimaryToProxyMessage, Transaction,
+        PrimaryToProxyMessage, RemoraTransaction,
     },
     metrics::Metrics,
     primary::core::PendingTransactions,
@@ -23,9 +23,9 @@ use crate::{
 /// A load balancer is responsible for distributing transactions to the consensus and proxies.
 pub struct LoadBalancer<E: Executor> {
     /// The receiver for transactions.
-    rx_transactions: Receiver<Transaction<E>>,
+    rx_transactions: Receiver<RemoraTransaction<E>>,
     /// The sender to forward transactions to the consensus.
-    tx_consensus: Sender<Transaction<E>>,
+    tx_consensus: Sender<RemoraTransaction<E>>,
     /// Receive handles to forward transactions to proxies. When a new client connects,
     /// this channel receives a sender from the network layer which is used to forward
     /// transactions to the proxies.
@@ -33,7 +33,7 @@ pub struct LoadBalancer<E: Executor> {
     /// Holds senders to forward transactions to proxies.
     proxy_connections: Vec<Sender<PrimaryToProxyMessage<<E as Executor>::Transaction>>>,
     /// The receiver for committed transactions
-    rx_committed_txns: Receiver<Transaction<E>>,
+    rx_committed_txns: Receiver<RemoraTransaction<E>>,
     /// Keeps track of every attempt to forward a transaction to a proxy.
     index: ExecutorIndex,
     /// Keeps track of shared-objects and its shards (proxy)
@@ -41,7 +41,7 @@ pub struct LoadBalancer<E: Executor> {
     /// The transactions sent out to proxies
     pending_txns: PendingTransactions<E>,
     /// The sender to a local executor if no pre-executor is available.
-    tx_executor_local: Sender<Transaction<E>>,
+    tx_executor_local: Sender<RemoraTransaction<E>>,
     /// The receiver of new effects from local executor and needs to forward to proxies.
     rx_states_sync: Receiver<ExecutionResults<E>>,
     /// The metrics for the validator.
@@ -51,12 +51,12 @@ pub struct LoadBalancer<E: Executor> {
 impl<E: Executor> LoadBalancer<E> {
     /// Create a new load balancer.
     pub fn new(
-        rx_transactions: Receiver<Transaction<E>>,
-        tx_consensus: Sender<Transaction<E>>,
+        rx_transactions: Receiver<RemoraTransaction<E>>,
+        tx_consensus: Sender<RemoraTransaction<E>>,
         rx_proxy_connections: Receiver<Sender<PrimaryToProxyMessage<<E as Executor>::Transaction>>>,
-        rx_committed_txns: Receiver<Transaction<E>>,
+        rx_committed_txns: Receiver<RemoraTransaction<E>>,
         pending_txns: PendingTransactions<E>,
-        tx_executor_local: Sender<Transaction<E>>,
+        tx_executor_local: Sender<RemoraTransaction<E>>,
         rx_states_sync: Receiver<ExecutionResults<E>>,
         metrics: Arc<Metrics>,
     ) -> Self {
@@ -76,7 +76,7 @@ impl<E: Executor> LoadBalancer<E> {
     }
 
     /// Forward a transaction to the consensus.
-    async fn send_to_consensus(&mut self, transaction: Transaction<E>) -> NodeResult<()> {
+    async fn send_to_consensus(&mut self, transaction: RemoraTransaction<E>) -> NodeResult<()> {
         if self.index == 0 {
             self.metrics.register_start_time();
         }
@@ -251,7 +251,7 @@ impl<E: Executor> LoadBalancer<E> {
     pub fn spawn(mut self) -> JoinHandle<NodeResult<()>>
     where
         E: Send + 'static,
-        Transaction<E>: Send + Sync,
+        RemoraTransaction<E>: Send + Sync,
         ExecutionResults<E>: Send,
     {
         tokio::spawn(async move { self.run().await })

--- a/crates/remora/src/proxy/core.rs
+++ b/crates/remora/src/proxy/core.rs
@@ -16,13 +16,8 @@ use crate::{
     error::{NodeError, NodeResult},
     executor::{
         api::{
-            ExecutableTransaction,
-            ExecutionResults,
-            Executor,
-            PrimaryToProxyMessage,
-            StateStore,
-            Store,
-            Transaction,
+            ExecutableTransaction, ExecutionResults, Executor, PrimaryToProxyMessage,
+            RemoraTransaction, StateStore, Store,
         },
         dependency_controller::DependencyController,
     },
@@ -90,7 +85,7 @@ impl<E: Executor> ProxyCore<E> {
     where
         E: Send + 'static,
         Store<E>: Send + Sync,
-        Transaction<E>: Send + Sync,
+        RemoraTransaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
     {
         tracing::info!("Proxy {} started", self.id);
@@ -151,7 +146,7 @@ impl<E: Executor> ProxyCore<E> {
 
     pub fn get_dependencies(
         &mut self,
-        transaction: Transaction<E>,
+        transaction: RemoraTransaction<E>,
         task_id: u64,
     ) -> (Vec<Arc<Notify>>, Vec<Arc<Notify>>) {
         // filter pkg id from the obj_id
@@ -179,14 +174,14 @@ impl<E: Executor> ProxyCore<E> {
 
     pub async fn schedule_txn_parallel(
         &mut self,
-        transaction: Transaction<E>,
+        transaction: RemoraTransaction<E>,
         prior_handles: Vec<Arc<Notify>>,
         current_handles: Vec<Arc<Notify>>,
     ) -> NodeResult<()>
     where
         E: Send + 'static,
         Store<E>: Send + Sync,
-        Transaction<E>: Send + Sync,
+        RemoraTransaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
     {
         let store = self.store.clone();
@@ -236,7 +231,7 @@ impl<E: Executor> ProxyCore<E> {
     where
         E: Send + 'static,
         Store<E>: Send + Sync,
-        Transaction<E>: Send + Sync,
+        RemoraTransaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
     {
         tokio::spawn(async move { self.run().await })
@@ -246,7 +241,7 @@ impl<E: Executor> ProxyCore<E> {
     where
         E: Send + 'static,
         Store<E>: Send + Sync,
-        Transaction<E>: Send + Sync,
+        RemoraTransaction<E>: Send + Sync,
         ExecutionResults<E>: Send + Sync,
     {
         let num_threads = num_cpus::get();

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -301,6 +301,28 @@ impl SingleValidator {
         InMemoryObjectStore::new(objects)
     }
 
+    pub async fn assigned_shared_object_versions_on_transaction(
+        &self,
+        transactions: &[Transaction],
+    ) {
+        let transactions: Vec<_> = transactions
+            .iter()
+            .map(|tx| {
+                VerifiedExecutableTransaction::new_from_quorum_execution(
+                    VerifiedTransaction::new_unchecked(tx.clone()),
+                    0,
+                )
+            })
+            .collect();
+        self.epoch_store
+            .assign_shared_object_versions_idempotent(
+                self.get_validator().get_object_cache_reader().as_ref(),
+                &transactions,
+            )
+            .await
+            .unwrap();
+    }
+
     pub async fn assigned_shared_object_versions(&self, transactions: &[CertifiedTransaction]) {
         let transactions: Vec<_> = transactions
             .iter()


### PR DESCRIPTION
A quick hack of not using `CertifiedTransaction`.

The main changes are following:

1. Replace `CertifiedTransaction` via `sui_types::transaction::Transaction` which has `EmptySignInfo`
2. Move `certify_transaction` call into the beginning of `E::execute`
3. Rename the original `Transaction<E>` trait to `RemoraTransaction<E>` given the introduction of sui_types's `Transaction`
4. Ignore the shared-transaction load generation. Plan to handle it later.