### PR TITLE
signature verification on the proxy

### DIFF
--- a/crates/remora/src/config.rs
+++ b/crates/remora/src/config.rs
@@ -3,8 +3,7 @@
 
 use std::{
     fmt::Debug,
-    fs,
-    io,
+    fs, io,
     net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
     path::Path,
     time::Duration,

--- a/crates/remora/src/executor/api.rs
+++ b/crates/remora/src/executor/api.rs
@@ -80,11 +80,21 @@ pub struct ExecutionResultsAndEffects<U: Clone + Debug> {
 
 impl<U: TransactionEffectsAPI + Clone + Debug> ExecutionResultsAndEffects<U> {
     pub fn new(updates: U, new_state: BTreeMap<ObjectID, Object>) -> Self {
-        Self { updates:Some(updates.clone()), new_state, authentication_success: true, transaction_digest: *updates.transaction_digest() }
+        Self {
+            updates: Some(updates.clone()),
+            new_state,
+            authentication_success: true,
+            transaction_digest: *updates.transaction_digest(),
+        }
     }
 
     pub fn new_from_failed_verification(transaction_digest: TransactionDigest) -> Self {
-        Self { updates: None, new_state: BTreeMap::new(), authentication_success: false, transaction_digest }
+        Self {
+            updates: None,
+            new_state: BTreeMap::new(),
+            authentication_success: false,
+            transaction_digest,
+        }
     }
 
     pub fn success(&self) -> bool {

--- a/crates/remora/src/executor/api.rs
+++ b/crates/remora/src/executor/api.rs
@@ -98,7 +98,13 @@ impl<U: TransactionEffectsAPI + Clone + Debug> ExecutionResultsAndEffects<U> {
     }
 
     pub fn success(&self) -> bool {
-        self.authentication_success && self.updates.as_ref().unwrap().status().is_ok()
+        if self.authentication_success {
+            if let Some(updates) = &self.updates {
+                return updates.status().is_ok();
+            }
+            return false;
+        }
+        false
     }
 
     pub fn transaction_digest(&self) -> &TransactionDigest {
@@ -106,7 +112,11 @@ impl<U: TransactionEffectsAPI + Clone + Debug> ExecutionResultsAndEffects<U> {
     }
 
     pub fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)> {
-        self.updates.as_ref().unwrap().modified_at_versions()
+        if let Some(updates) = &self.updates {
+            updates.modified_at_versions()
+        } else {
+            vec![]
+        }
     }
 }
 

--- a/crates/remora/src/executor/fake.rs
+++ b/crates/remora/src/executor/fake.rs
@@ -400,6 +400,17 @@ impl Executor for FakeExecutor {
         }
         true
     }
+
+    // busy loop to simulate transaction verification
+    fn verify_transaction(
+            ctx: Arc<FakeExecutionContext>, 
+            _transaction: &TransactionWithTimestamp<Self::Transaction>,
+        ) -> bool {
+        for _ in 0..ctx.checks_spins {
+            std::hint::spin_loop();
+        }
+        true
+    }
 }
 
 #[cfg(test)]

--- a/crates/remora/src/executor/fake.rs
+++ b/crates/remora/src/executor/fake.rs
@@ -23,10 +23,7 @@ use sui_types::{
 use tokio::time::Instant;
 
 use super::api::{
-    ExecutableTransaction,
-    ExecutionResultsAndEffects,
-    Executor,
-    StateStore,
+    ExecutableTransaction, ExecutionResultsAndEffects, Executor, StateStore,
     TransactionWithTimestamp,
 };
 
@@ -403,9 +400,9 @@ impl Executor for FakeExecutor {
 
     // busy loop to simulate transaction verification
     fn verify_transaction(
-            ctx: Arc<FakeExecutionContext>, 
-            _transaction: &TransactionWithTimestamp<Self::Transaction>,
-        ) -> bool {
+        ctx: Arc<FakeExecutionContext>,
+        _transaction: &TransactionWithTimestamp<Self::Transaction>,
+    ) -> bool {
         for _ in 0..ctx.checks_spins {
             std::hint::spin_loop();
         }
@@ -423,12 +420,8 @@ mod tests {
     use crate::executor::{
         api::{Executor, TransactionWithTimestamp},
         fake::{
-            fake_owned_object,
-            fake_shared_object,
-            FakeExecutionContext,
-            FakeExecutor,
-            FakeObjectStore,
-            FakeTransaction,
+            fake_owned_object, fake_shared_object, FakeExecutionContext, FakeExecutor,
+            FakeObjectStore, FakeTransaction,
         },
     };
 

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -339,6 +339,13 @@ impl Executor for SuiExecutor {
             .read_objects_for_execution(&**epoch_store, &transaction.key(), &input_objects)
             .is_ok()
     }
+
+    fn verify_transaction(
+            ctx: Arc<BenchmarkContext>,
+            transaction: &super::api::TransactionWithTimestamp<Self::Transaction>,
+        ) -> bool {
+        transaction.deref().clone().try_into_verified_for_testing(ctx.get_committee(), &Default::default()).is_ok()
+    }
 }
 
 #[cfg(test)]

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -344,6 +344,7 @@ impl Executor for SuiExecutor {
         ctx: Arc<BenchmarkContext>,
         transaction: &super::api::TransactionWithTimestamp<Self::Transaction>,
     ) -> bool {
+        // Verify the transaction using default verify parameters (&Default::default())
         transaction
             .deref()
             .clone()

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -341,10 +341,14 @@ impl Executor for SuiExecutor {
     }
 
     fn verify_transaction(
-            ctx: Arc<BenchmarkContext>,
-            transaction: &super::api::TransactionWithTimestamp<Self::Transaction>,
-        ) -> bool {
-        transaction.deref().clone().try_into_verified_for_testing(ctx.get_committee(), &Default::default()).is_ok()
+        ctx: Arc<BenchmarkContext>,
+        transaction: &super::api::TransactionWithTimestamp<Self::Transaction>,
+    ) -> bool {
+        transaction
+            .deref()
+            .clone()
+            .try_into_verified_for_testing(ctx.get_committee(), &Default::default())
+            .is_ok()
     }
 }
 

--- a/crates/remora/src/primary/core.rs
+++ b/crates/remora/src/primary/core.rs
@@ -96,8 +96,9 @@ impl<E: Executor> PrimaryCore<E> {
             }
             if skip {
                 let effects = proxy_result.clone();
-                self.store
-                    .commit_objects(effects.updates.unwrap(), effects.new_state);
+                if let Some(updates) = effects.updates {
+                    self.store.commit_objects(updates, effects.new_state);
+                }
                 return proxy_result;
             }
         }
@@ -167,6 +168,7 @@ mod tests {
 
     #[tokio::test]
     #[tracing_test::traced_test]
+    // Test the merging of results from the proxy and the primary executor when transactions are correctly signed.
     async fn merge_results() {
         let (tx_commit, rx_commit) = mpsc::channel(100);
         let (tx_results, rx_results) = mpsc::channel(100);
@@ -213,6 +215,7 @@ mod tests {
 
     #[tokio::test]
     #[tracing_test::traced_test]
+    // Test the merging of results from the proxy and the primary executor when transactions are not correctly signed.
     async fn merge_results_unsigned() {
         let (tx_commit, rx_commit) = mpsc::channel(100);
         let (tx_results, rx_results) = mpsc::channel(100);

--- a/crates/remora/src/primary/core.rs
+++ b/crates/remora/src/primary/core.rs
@@ -17,12 +17,7 @@ use super::mock_consensus::ConsensusCommit;
 use crate::{
     error::{NodeError, NodeResult},
     executor::api::{
-        ExecutableTransaction,
-        ExecutionResults,
-        Executor,
-        StateStore,
-        Store,
-        Transaction,
+        ExecutableTransaction, ExecutionResults, Executor, StateStore, Store, Transaction,
     },
 };
 

--- a/crates/remora/src/primary/node.rs
+++ b/crates/remora/src/primary/node.rs
@@ -165,10 +165,7 @@ mod tests {
 
     use crate::{
         config::{
-            BenchmarkParameters,
-            CollocatedPreExecutors,
-            ValidatorConfig,
-            ValidatorParameters,
+            BenchmarkParameters, CollocatedPreExecutors, ValidatorConfig, ValidatorParameters,
         },
         executor::sui::SuiExecutor,
         load_generator::LoadGenerator,

--- a/crates/remora/src/proxy/core.rs
+++ b/crates/remora/src/proxy/core.rs
@@ -83,8 +83,13 @@ impl<E: Executor> ProxyCore<E> {
             ProxyMode::SingleThreaded => {
                 while let Some(transaction) = self.rx_transactions.recv().await {
                     self.metrics.increase_proxy_load(&self.id);
-                    let execution_result =
-                        E::execute(self.executor.context(), self.store.clone(), &transaction).await;
+                    // check authentication first. If the tx fails authentication, no need to execute
+                    let execution_result = if !E::verify_transaction(self.executor.context(), &transaction) {
+                        // send an empty result if the transaction is invalid
+                        ExecutionResults::<E>::new_from_failed_verification(*transaction.digest())
+                    } else {
+                        E::execute(self.executor.context(), self.store.clone(), &transaction).await
+                    };
                     self.metrics.decrease_proxy_load(&self.id);
                     if self.tx_results.send(execution_result).await.is_err() {
                         tracing::warn!(
@@ -155,7 +160,13 @@ impl<E: Executor> ProxyCore<E> {
                         }
 
                         if ready_to_execute {
-                            let execution_result = E::execute(ctx, store, &transaction).await;
+                            // TODO igor: perhaps we can move the authentication verification earlier, so as not to waste time and resources on scheduling a tx that will fail authentication anyway
+                            let execution_result = if !E::verify_transaction(ctx.clone(), &transaction) {
+                            
+                                ExecutionResults::<E>::new_from_failed_verification(*transaction.digest())
+                            } else {
+                                E::execute(ctx, store, &transaction).await
+                            };
 
                             for notify in current_handles {
                                 notify.notify_one();
@@ -216,6 +227,7 @@ mod tests {
 
     use std::sync::Arc;
 
+    use sui_types::{message_envelope::Envelope, transaction::SenderSignedData};
     use tokio::sync::mpsc;
 
     use crate::{
@@ -225,7 +237,33 @@ mod tests {
         proxy::core::{ProxyCore, ProxyMode},
     };
 
-    async fn pre_execute(mode: ProxyMode) {
+    async fn new_signed_txs() -> Vec<SuiTransaction> {
+        let config = BenchmarkParameters::new_for_tests();
+        // Send transactions to the proxy.
+        let txs = generate_transactions(&config).await;
+        // wrap txs in SuiTransaction
+        txs.into_iter()
+            .map(|tx| SuiTransaction::new_for_tests(tx))
+            .collect::<Vec<_>>()
+    }
+
+    async fn new_unsigned_txs() -> Vec<SuiTransaction> {
+        let config = BenchmarkParameters::new_for_tests();
+
+        // Send transactions to the proxy.
+        let transactions = generate_transactions(&config).await;
+
+        transactions
+            .into_iter()
+            .map(|tx| {
+                let unsigned_sender_data = SenderSignedData::new(tx.transaction_data().clone(), vec![]);
+                let unsigned_tx = Envelope::new_from_data_and_sig(unsigned_sender_data, tx.auth_sig().clone());
+                SuiTransaction::new_for_tests(unsigned_tx)
+            })
+            .collect::<Vec<_>>()
+    }
+
+    async fn pre_execute(mode: ProxyMode, signed: bool) {
         let (tx_proxy, rx_proxy) = mpsc::channel(100);
         let (tx_results, mut rx_results) = mpsc::channel(100);
 
@@ -238,11 +276,17 @@ mod tests {
             proxy_id, executor, mode, store, rx_proxy, tx_results, metrics,
         );
 
+        let transactions = if signed {
+            new_signed_txs().await
+        } else {
+            new_unsigned_txs().await
+        };
+
         // Send transactions to the proxy.
-        let transactions = generate_transactions(&config).await;
+        // let transactions = generate_transactions(&config).await;
         for tx in transactions {
-            let transaction = SuiTransaction::new_for_tests(tx);
-            tx_proxy.send(transaction).await.unwrap();
+            // let transaction = SuiTransaction::new_for_tests(tx);
+            tx_proxy.send(tx).await.unwrap();
         }
 
         // Spawn the proxy.
@@ -250,16 +294,33 @@ mod tests {
 
         // Receive the results.
         let results = rx_results.recv().await.unwrap();
-        assert!(results.success());
+        
+        if signed {
+            assert!(results.authentication_success);
+            assert!(results.success());
+        } else {
+            assert!(!results.authentication_success);
+            assert!(!results.success())
+        }
     }
 
     #[tokio::test]
-    async fn test_single_threaded_proxy() {
-        pre_execute(ProxyMode::SingleThreaded).await;
+    async fn test_single_threaded_proxy_signed() {
+        pre_execute(ProxyMode::SingleThreaded, true).await;
     }
 
     #[tokio::test]
-    async fn test_multi_threaded_proxy() {
-        pre_execute(ProxyMode::MultiThreaded).await;
+    async fn test_multi_threaded_proxy_signed() {
+        pre_execute(ProxyMode::MultiThreaded, true).await;
+    }
+
+    #[tokio::test]
+    async fn test_single_threaded_proxy_unsigned() {
+        pre_execute(ProxyMode::SingleThreaded, false).await;
+    }
+
+    #[tokio::test]
+    async fn test_multi_threaded_proxy_unsigned() {
+        pre_execute(ProxyMode::MultiThreaded, false).await;
     }
 }

--- a/crates/remora/src/proxy/node.rs
+++ b/crates/remora/src/proxy/node.rs
@@ -7,10 +7,7 @@ use tokio::{sync::mpsc, task::JoinHandle};
 
 use super::core::{ProxyCore, ProxyId};
 use crate::{
-    config::ValidatorConfig,
-    error::NodeResult,
-    executor::sui::SuiExecutor,
-    metrics::Metrics,
+    config::ValidatorConfig, error::NodeResult, executor::sui::SuiExecutor, metrics::Metrics,
     networking::client::NetworkClient,
 };
 

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -11,11 +11,7 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use sui_config::node::RunWithRange;
 use sui_test_transaction_builder::PublishData;
 use sui_types::{
-    base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress},
-    effects::{TransactionEffects, TransactionEffectsAPI},
-    messages_grpc::HandleTransactionResponse,
-    mock_checkpoint_builder::ValidatorKeypairProvider,
-    transaction::{CertifiedTransaction, SignedTransaction, Transaction, VerifiedTransaction},
+    base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress}, committee::Committee, effects::{TransactionEffects, TransactionEffectsAPI}, messages_grpc::HandleTransactionResponse, mock_checkpoint_builder::ValidatorKeypairProvider, transaction::{CertifiedTransaction, SignedTransaction, Transaction, VerifiedTransaction}
 };
 use tokio::sync::mpsc::Sender;
 use tracing::info;
@@ -74,6 +70,10 @@ impl BenchmarkContext {
 
     pub fn validator(&self) -> SingleValidator {
         self.validator.clone()
+    }
+
+    pub fn get_committee(&self) -> &Committee {
+        self.validator.get_committee()
     }
 
     pub fn get_accounts(&self) -> &BTreeMap<SuiAddress, Account> {


### PR DESCRIPTION
Authentication verification on the proxy. The proxy verifies transaction authentication prior to execution. If the verification fails, the proxy skips transaction execution and informs the primary. In this case, the primary also skips merging the results and directly returns the transaction as failed.

