### PR TITLE
feat: Ethereum loads

### DIFF
--- a/crates/remora/assets/example-benchmark.yml
+++ b/crates/remora/assets/example-benchmark.yml
@@ -2,4 +2,4 @@ load: 3
 duration:
   secs: 60
   nanos: 0
-workload: !EthereumNftMint
+workload: !UniswapPeak

--- a/crates/remora/assets/example-benchmark.yml
+++ b/crates/remora/assets/example-benchmark.yml
@@ -2,4 +2,4 @@ load: 3
 duration:
   secs: 60
   nanos: 0
-workload: !EthereumTransfers
+workload: !EthereumNftMint

--- a/crates/remora/assets/example-benchmark.yml
+++ b/crates/remora/assets/example-benchmark.yml
@@ -2,4 +2,4 @@ load: 3
 duration:
   secs: 60
   nanos: 0
-workload: !SolanaTransactions
+workload: !EthereumTransfers

--- a/crates/remora/src/bin/load_generator.rs
+++ b/crates/remora/src/bin/load_generator.rs
@@ -56,7 +56,8 @@ async fn main() -> anyhow::Result<()> {
         }
         WorkloadType::SharedObjects { .. }
         | WorkloadType::SolanaTransactions
-        | WorkloadType::EthereumTransfers => {
+        | WorkloadType::EthereumTransfers
+        | WorkloadType::EthereumNftMint => {
             transactions = load_generator.initialize().await;
             tracing::debug!(
                 "Transactions: {:?}",

--- a/crates/remora/src/bin/load_generator.rs
+++ b/crates/remora/src/bin/load_generator.rs
@@ -57,7 +57,9 @@ async fn main() -> anyhow::Result<()> {
         WorkloadType::SharedObjects { .. }
         | WorkloadType::SolanaTransactions
         | WorkloadType::EthereumTransfers
-        | WorkloadType::EthereumNftMint => {
+        | WorkloadType::EthereumNftMint
+        | WorkloadType::UniswapNormal
+        | WorkloadType::UniswapPeak => {
             transactions = load_generator.initialize().await;
             tracing::debug!(
                 "Transactions: {:?}",

--- a/crates/remora/src/bin/load_generator.rs
+++ b/crates/remora/src/bin/load_generator.rs
@@ -54,7 +54,9 @@ async fn main() -> anyhow::Result<()> {
         WorkloadType::Transfers => {
             transactions = load_generator.initialize().await;
         }
-        WorkloadType::SharedObjects { .. } | WorkloadType::SolanaTransactions => {
+        WorkloadType::SharedObjects { .. }
+        | WorkloadType::SolanaTransactions
+        | WorkloadType::EthereumTransfers => {
             transactions = load_generator.initialize().await;
             tracing::debug!(
                 "Transactions: {:?}",

--- a/crates/remora/src/bin/remora.rs
+++ b/crates/remora/src/bin/remora.rs
@@ -70,7 +70,8 @@ async fn main() -> anyhow::Result<()> {
     match benchmark_config.workload {
         WorkloadType::Transfers
         | WorkloadType::SharedObjects { .. }
-        | WorkloadType::SolanaTransactions => {
+        | WorkloadType::SolanaTransactions
+        | WorkloadType::EthereumTransfers => {
             let executor = SuiExecutor::new(&benchmark_config).await;
             start_node(
                 args.role,

--- a/crates/remora/src/bin/remora.rs
+++ b/crates/remora/src/bin/remora.rs
@@ -72,7 +72,9 @@ async fn main() -> anyhow::Result<()> {
         | WorkloadType::SharedObjects { .. }
         | WorkloadType::SolanaTransactions
         | WorkloadType::EthereumTransfers
-        | WorkloadType::EthereumNftMint => {
+        | WorkloadType::EthereumNftMint
+        | WorkloadType::UniswapNormal
+        | WorkloadType::UniswapPeak => {
             let executor = SuiExecutor::new(&benchmark_config).await;
             start_node(
                 args.role,

--- a/crates/remora/src/bin/remora.rs
+++ b/crates/remora/src/bin/remora.rs
@@ -71,7 +71,8 @@ async fn main() -> anyhow::Result<()> {
         WorkloadType::Transfers
         | WorkloadType::SharedObjects { .. }
         | WorkloadType::SolanaTransactions
-        | WorkloadType::EthereumTransfers => {
+        | WorkloadType::EthereumTransfers
+        | WorkloadType::EthereumNftMint => {
             let executor = SuiExecutor::new(&benchmark_config).await;
             start_node(
                 args.role,

--- a/crates/remora/src/config.rs
+++ b/crates/remora/src/config.rs
@@ -176,6 +176,8 @@ pub enum WorkloadType {
     SolanaTransactions,
     EthereumTransfers,
     EthereumNftMint,
+    UniswapNormal,
+    UniswapPeak,
 }
 
 fn default_cont_level_for_shared_obj() -> usize {
@@ -200,6 +202,8 @@ impl Debug for WorkloadType {
             WorkloadType::SolanaTransactions => write!(f, "Solana transactions"),
             WorkloadType::EthereumTransfers => write!(f, "Ethereum transfers"),
             WorkloadType::EthereumNftMint => write!(f, "Ethereum NFT mint"),
+            WorkloadType::UniswapNormal => write!(f, "Uniswap normal"),
+            WorkloadType::UniswapPeak => write!(f, "Uniswap peak"),
         }
     }
 }

--- a/crates/remora/src/config.rs
+++ b/crates/remora/src/config.rs
@@ -174,6 +174,7 @@ pub enum WorkloadType {
         contention: u64,
     },
     SolanaTransactions,
+    EthereumTransfers,
 }
 
 fn default_cont_level_for_shared_obj() -> usize {
@@ -196,6 +197,7 @@ impl Debug for WorkloadType {
             WorkloadType::FakedNoContention { .. } => write!(f, "faked no contention"),
             WorkloadType::FakedContention { .. } => write!(f, "faked contention"),
             WorkloadType::SolanaTransactions => write!(f, "Solana transactions"),
+            WorkloadType::EthereumTransfers => write!(f, "Ethereum transfers"),
         }
     }
 }

--- a/crates/remora/src/config.rs
+++ b/crates/remora/src/config.rs
@@ -175,6 +175,7 @@ pub enum WorkloadType {
     },
     SolanaTransactions,
     EthereumTransfers,
+    EthereumNftMint,
 }
 
 fn default_cont_level_for_shared_obj() -> usize {
@@ -198,6 +199,7 @@ impl Debug for WorkloadType {
             WorkloadType::FakedContention { .. } => write!(f, "faked contention"),
             WorkloadType::SolanaTransactions => write!(f, "Solana transactions"),
             WorkloadType::EthereumTransfers => write!(f, "Ethereum transfers"),
+            WorkloadType::EthereumNftMint => write!(f, "Ethereum NFT mint"),
         }
     }
 }

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -98,6 +98,7 @@ pub fn init_workload(config: &BenchmarkParameters) -> Workload {
             txs_per_counter: txs_per_counter as u64,
         }),
         WorkloadType::SolanaTransactions => Ok(WorkloadKind::SolanaTransactions),
+        WorkloadType::EthereumTransfers => Ok(WorkloadKind::EthereumTransfers),
         _ => Err(ConfigErrorType::InvalidWorkload),
     };
 

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -99,6 +99,7 @@ pub fn init_workload(config: &BenchmarkParameters) -> Workload {
         }),
         WorkloadType::SolanaTransactions => Ok(WorkloadKind::SolanaTransactions),
         WorkloadType::EthereumTransfers => Ok(WorkloadKind::EthereumTransfers),
+        WorkloadType::EthereumNftMint => Ok(WorkloadKind::EthereumNftMint),
         _ => Err(ConfigErrorType::InvalidWorkload),
     };
 

--- a/crates/remora/src/executor/sui.rs
+++ b/crates/remora/src/executor/sui.rs
@@ -100,6 +100,8 @@ pub fn init_workload(config: &BenchmarkParameters) -> Workload {
         WorkloadType::SolanaTransactions => Ok(WorkloadKind::SolanaTransactions),
         WorkloadType::EthereumTransfers => Ok(WorkloadKind::EthereumTransfers),
         WorkloadType::EthereumNftMint => Ok(WorkloadKind::EthereumNftMint),
+        WorkloadType::UniswapNormal => Ok(WorkloadKind::UniswapNormal),
+        WorkloadType::UniswapPeak => Ok(WorkloadKind::UniswapPeak),
         _ => Err(ConfigErrorType::InvalidWorkload),
     };
 

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -160,6 +160,8 @@ pub enum WorkloadKind {
     SolanaTransactions,
     EthereumTransfers,
     EthereumNftMint,
+    UniswapNormal,
+    UniswapPeak,
 }
 
 impl WorkloadKind {
@@ -173,6 +175,8 @@ impl WorkloadKind {
             Self::SolanaTransactions => 1,
             Self::EthereumTransfers => 1,
             Self::EthereumNftMint => 1,
+            Self::UniswapNormal => 1,
+            Self::UniswapPeak => 1,
         }
     }
 
@@ -280,6 +284,72 @@ impl WorkloadKind {
                         id
                     });
                     stats.insert(tx_id, vec![nft, minter]);
+                }
+
+                // Convert raw object digests to object ids.
+                let stats: HashMap<usize, _> = stats
+                    .into_iter()
+                    .map(|(tx_id, inputs)| {
+                        let inputs = inputs
+                            .into_iter()
+                            .map(|input| *object_ids_map.get(&input).unwrap())
+                            .collect();
+                        (tx_id, inputs)
+                    })
+                    .collect();
+
+                let num_of_distinct_objects = object_ids_map.len();
+                Some((num_of_distinct_objects, stats))
+            }
+            Self::UniswapNormal => {
+                // Maps transaction ids to the object digests they access.
+                let mut stats = HashMap::new();
+
+                // Maps raw object digests to consecutive object ids.
+                let mut object_ids_map = HashMap::new();
+                let mut next_object_id = 0;
+
+                for tx_id in 0..tx_count {
+                    let coin_pair = crate::load_statistics::ethereum_uniswap_normal(&mut rng);
+                    object_ids_map.entry(coin_pair).or_insert_with(|| {
+                        let id = next_object_id;
+                        next_object_id += 1;
+                        id
+                    });
+                    stats.insert(tx_id, vec![coin_pair]);
+                }
+
+                // Convert raw object digests to object ids.
+                let stats: HashMap<usize, _> = stats
+                    .into_iter()
+                    .map(|(tx_id, inputs)| {
+                        let inputs = inputs
+                            .into_iter()
+                            .map(|input| *object_ids_map.get(&input).unwrap())
+                            .collect();
+                        (tx_id, inputs)
+                    })
+                    .collect();
+
+                let num_of_distinct_objects = object_ids_map.len();
+                Some((num_of_distinct_objects, stats))
+            }
+            Self::UniswapPeak => {
+                // Maps transaction ids to the object digests they access.
+                let mut stats = HashMap::new();
+
+                // Maps raw object digests to consecutive object ids.
+                let mut object_ids_map = HashMap::new();
+                let mut next_object_id = 0;
+
+                for tx_id in 0..tx_count {
+                    let coin_pair = crate::load_statistics::ethereum_uniswap_peak(&mut rng);
+                    object_ids_map.entry(coin_pair).or_insert_with(|| {
+                        let id = next_object_id;
+                        next_object_id += 1;
+                        id
+                    });
+                    stats.insert(tx_id, vec![coin_pair]);
                 }
 
                 // Convert raw object digests to object ids.

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -158,17 +158,19 @@ pub enum WorkloadKind {
         txs_per_counter: u64,
     },
     SolanaTransactions,
+    EthereumTransfers,
 }
 
 impl WorkloadKind {
     pub(crate) fn gas_object_num_per_account(&self) -> u64 {
         match self {
             // Each transaction will always have 1 gas object, plus the number of owned objects that will be transferred.
-            WorkloadKind::NoMove => 1,
-            WorkloadKind::PTB { num_transfers, .. } => *num_transfers + 1,
-            WorkloadKind::Publish { .. } => 1,
-            WorkloadKind::Counter { txs_per_counter } => *txs_per_counter,
-            WorkloadKind::SolanaTransactions => 1,
+            Self::NoMove => 1,
+            Self::PTB { num_transfers, .. } => *num_transfers + 1,
+            Self::Publish { .. } => 1,
+            Self::Counter { txs_per_counter } => *txs_per_counter,
+            Self::SolanaTransactions => 1,
+            Self::EthereumTransfers => 1,
         }
     }
 
@@ -198,6 +200,44 @@ impl WorkloadKind {
                         });
                     }
                     stats.insert(tx_id, inputs);
+                }
+
+                // Convert raw object digests to object ids.
+                let stats: HashMap<usize, _> = stats
+                    .into_iter()
+                    .map(|(tx_id, inputs)| {
+                        let inputs = inputs
+                            .into_iter()
+                            .map(|input| *object_ids_map.get(&input).unwrap())
+                            .collect();
+                        (tx_id, inputs)
+                    })
+                    .collect();
+
+                let num_of_distinct_objects = object_ids_map.len();
+                Some((num_of_distinct_objects, stats))
+            }
+            Self::EthereumTransfers => {
+                // Maps transaction ids to the object digests they access.
+                let mut stats = HashMap::new();
+
+                // Maps raw object digests to consecutive object ids.
+                let mut object_ids_map = HashMap::new();
+                let mut next_object_id = 0;
+
+                for tx_id in 0..tx_count {
+                    let (sender, recipient) = crate::load_statistics::ethereum_transfers(&mut rng);
+                    object_ids_map.entry(sender).or_insert_with(|| {
+                        let id = next_object_id;
+                        next_object_id += 1;
+                        id
+                    });
+                    object_ids_map.entry(recipient).or_insert_with(|| {
+                        let id = next_object_id;
+                        next_object_id += 1;
+                        id
+                    });
+                    stats.insert(tx_id, vec![sender, recipient]);
                 }
 
                 // Convert raw object digests to object ids.

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -159,6 +159,7 @@ pub enum WorkloadKind {
     },
     SolanaTransactions,
     EthereumTransfers,
+    EthereumNftMint,
 }
 
 impl WorkloadKind {
@@ -171,6 +172,7 @@ impl WorkloadKind {
             Self::Counter { txs_per_counter } => *txs_per_counter,
             Self::SolanaTransactions => 1,
             Self::EthereumTransfers => 1,
+            Self::EthereumNftMint => 1,
         }
     }
 
@@ -180,6 +182,8 @@ impl WorkloadKind {
         tx_count: usize,
     ) -> Option<(usize, HashMap<usize, Vec<usize>>)> {
         let mut rng = StdRng::seed_from_u64(0);
+
+        // TODO: Tidy these functions once we have them all.
 
         match self {
             Self::SolanaTransactions => {
@@ -255,7 +259,48 @@ impl WorkloadKind {
                 let num_of_distinct_objects = object_ids_map.len();
                 Some((num_of_distinct_objects, stats))
             }
-            _ => None,
+            Self::EthereumNftMint => {
+                // Maps transaction ids to the object digests they access.
+                let mut stats = HashMap::new();
+
+                // Maps raw object digests to consecutive object ids.
+                let mut object_ids_map = HashMap::new();
+                let mut next_object_id = 0;
+
+                for tx_id in 0..tx_count {
+                    let (nft, minter) = crate::load_statistics::ethereum_nft_mint(&mut rng);
+                    object_ids_map.entry(nft).or_insert_with(|| {
+                        let id = next_object_id;
+                        next_object_id += 1;
+                        id
+                    });
+                    object_ids_map.entry(minter).or_insert_with(|| {
+                        let id = next_object_id;
+                        next_object_id += 1;
+                        id
+                    });
+                    stats.insert(tx_id, vec![nft, minter]);
+                }
+
+                // Convert raw object digests to object ids.
+                let stats: HashMap<usize, _> = stats
+                    .into_iter()
+                    .map(|(tx_id, inputs)| {
+                        let inputs = inputs
+                            .into_iter()
+                            .map(|input| *object_ids_map.get(&input).unwrap())
+                            .collect();
+                        (tx_id, inputs)
+                    })
+                    .collect();
+
+                let num_of_distinct_objects = object_ids_map.len();
+                Some((num_of_distinct_objects, stats))
+            }
+            WorkloadKind::NoMove
+            | WorkloadKind::PTB { .. }
+            | WorkloadKind::Publish { .. }
+            | WorkloadKind::Counter { .. } => None,
         }
     }
 }

--- a/crates/sui-single-node-benchmark/src/workload.rs
+++ b/crates/sui-single-node-benchmark/src/workload.rs
@@ -38,13 +38,20 @@ impl Workload {
 
     pub fn num_accounts(&self) -> u64 {
         match self.workload_kind {
+            WorkloadKind::NoMove | WorkloadKind::PTB { .. } | WorkloadKind::Publish { .. } => {
+                self.tx_count
+            }
             WorkloadKind::Counter { txs_per_counter } => self.tx_count / txs_per_counter,
             WorkloadKind::SolanaTransactions => self
                 .stats
                 .as_ref()
                 .map(|(distinct_objects, stats)| stats.keys().len().max(*distinct_objects) as u64)
                 .unwrap(),
-            _ => self.tx_count,
+            WorkloadKind::EthereumTransfers => self
+                .stats
+                .as_ref()
+                .map(|(distinct_objects, stats)| stats.keys().len().max(*distinct_objects) as u64)
+                .unwrap(),
         }
     }
 
@@ -113,23 +120,22 @@ impl Workload {
                     *txs_per_counter,
                 ))
             }
-            WorkloadKind::SolanaTransactions => {
+            WorkloadKind::SolanaTransactions | WorkloadKind::EthereumTransfers => {
                 let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
                 path.extend(["move_package"]);
                 let move_package = ctx.publish_package(PublishData::Source(path, false)).await;
 
                 let stats = &self.stats.as_ref().expect("Stats should be already built");
 
-                // generate counter objects. For internal implementation reasons, there must be at
+                // Generate counter objects. For internal implementation reasons, there must be at
                 // least one account per shared object.
                 let num_of_counters = stats.0;
                 let counter_objects = ctx
                     .prepare_shared_objects(move_package.0, num_of_counters)
                     .await;
 
-                let mut account_orders: HashMap<SuiAddress, usize> = HashMap::new();
-
                 // Iterate over the values and assign a unique index to each
+                let mut account_orders: HashMap<SuiAddress, usize> = HashMap::new();
                 for (idx, value) in ctx.get_accounts().keys().enumerate() {
                     account_orders.insert(*value, idx);
                 }

--- a/crates/sui-single-node-benchmark/src/workload.rs
+++ b/crates/sui-single-node-benchmark/src/workload.rs
@@ -44,7 +44,9 @@ impl Workload {
             WorkloadKind::Counter { txs_per_counter } => self.tx_count / txs_per_counter,
             WorkloadKind::SolanaTransactions
             | WorkloadKind::EthereumTransfers
-            | WorkloadKind::EthereumNftMint => self
+            | WorkloadKind::EthereumNftMint
+            | WorkloadKind::UniswapNormal
+            | WorkloadKind::UniswapPeak => self
                 .stats
                 .as_ref()
                 .map(|(distinct_objects, stats)| stats.keys().len().max(*distinct_objects) as u64)
@@ -119,7 +121,9 @@ impl Workload {
             }
             WorkloadKind::SolanaTransactions
             | WorkloadKind::EthereumTransfers
-            | WorkloadKind::EthereumNftMint => {
+            | WorkloadKind::EthereumNftMint
+            | WorkloadKind::UniswapNormal
+            | WorkloadKind::UniswapPeak => {
                 let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
                 path.extend(["move_package"]);
                 let move_package = ctx.publish_package(PublishData::Source(path, false)).await;

--- a/crates/sui-single-node-benchmark/src/workload.rs
+++ b/crates/sui-single-node-benchmark/src/workload.rs
@@ -42,12 +42,9 @@ impl Workload {
                 self.tx_count
             }
             WorkloadKind::Counter { txs_per_counter } => self.tx_count / txs_per_counter,
-            WorkloadKind::SolanaTransactions => self
-                .stats
-                .as_ref()
-                .map(|(distinct_objects, stats)| stats.keys().len().max(*distinct_objects) as u64)
-                .unwrap(),
-            WorkloadKind::EthereumTransfers => self
+            WorkloadKind::SolanaTransactions
+            | WorkloadKind::EthereumTransfers
+            | WorkloadKind::EthereumNftMint => self
                 .stats
                 .as_ref()
                 .map(|(distinct_objects, stats)| stats.keys().len().max(*distinct_objects) as u64)
@@ -120,7 +117,9 @@ impl Workload {
                     *txs_per_counter,
                 ))
             }
-            WorkloadKind::SolanaTransactions | WorkloadKind::EthereumTransfers => {
+            WorkloadKind::SolanaTransactions
+            | WorkloadKind::EthereumTransfers
+            | WorkloadKind::EthereumNftMint => {
                 let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
                 path.extend(["move_package"]);
                 let move_package = ctx.publish_package(PublishData::Source(path, false)).await;


### PR DESCRIPTION
Add Ethereum loads on the Sui executor, implemented as shared objects.

Next steps are (1) also implement some of them (transfers and NFTs) as owned objects; and (2) implement them on the fake executor.