### PR TITLE
Parallel sampling from eth/solana load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9932,6 +9932,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13948,6 +13957,7 @@ dependencies = [
  "bcs",
  "bincode",
  "clap",
+ "dashmap",
  "fastcrypto",
  "fs_extra",
  "futures",
@@ -13959,7 +13969,10 @@ dependencies = [
  "once_cell",
  "prometheus",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.9.2",
  "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -16785,6 +16798,26 @@ dependencies = [
  "tokio",
  "tower-service",
  "url",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/crates/remora/assets/example-benchmark.yml
+++ b/crates/remora/assets/example-benchmark.yml
@@ -1,5 +1,5 @@
-load: 3
+load: 10000 
 duration:
   secs: 60
   nanos: 0
-workload: !UniswapPeak
+workload: !EthereumTransfers

--- a/crates/sui-single-node-benchmark/Cargo.toml
+++ b/crates/sui-single-node-benchmark/Cargo.toml
@@ -39,7 +39,7 @@ bincode = "1.3.3"
 rand_distr = "0.4.3"
 dashmap.workspace = true
 rayon.workspace = true
-rand_chacha = "0.9.0"
+rand_chacha = "0.3.1"
 rand_core = "0.9.2"
 
 [dev-dependencies]

--- a/crates/sui-single-node-benchmark/Cargo.toml
+++ b/crates/sui-single-node-benchmark/Cargo.toml
@@ -37,6 +37,10 @@ tracing.workspace = true
 num_cpus.workspace = true
 bincode = "1.3.3"
 rand_distr = "0.4.3"
+dashmap.workspace = true
+rayon.workspace = true
+rand_chacha = "0.9.0"
+rand_core = "0.9.2"
 
 [dev-dependencies]
 sui-macros.workspace = true

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -1,10 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{collections::HashMap, path::PathBuf};
 
+use dashmap::DashMap;
+use rand_chacha::ChaCha8Rng;
+use rayon::prelude::*;
+
 use clap::{Parser, Subcommand, ValueEnum};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::SeedableRng;
 use strum_macros::EnumIter;
 
 #[derive(Parser)]
@@ -164,6 +169,60 @@ pub enum WorkloadKind {
     UniswapPeak,
 }
 
+/// Parallelized transaction processing with deterministic RNG
+fn build_stats_common<F>(
+    tx_count: usize,
+    tx_generator: F,
+) -> Option<(usize, HashMap<usize, Vec<usize>>)>
+where
+    F: Fn(&mut ChaCha8Rng) -> Vec<usize> + Send + Sync,
+{
+    let num_threads = num_cpus::get();
+    let tx_batch_size = (tx_count / num_threads).max(10_000);
+    let tx_batches = (tx_count + tx_batch_size - 1) / tx_batch_size;
+
+    println!("Total Transactions: {}", tx_count);
+    println!("Using {} Threads", num_threads);
+    println!("Batch Size: {}", tx_batch_size);
+    println!("Total Batches: {}", tx_batches);
+
+    let object_ids_map = DashMap::new();
+    let next_object_id = AtomicUsize::new(0);
+
+    // Generate transactions in parallel
+    let stats: HashMap<usize, Vec<usize>> = (0..tx_batches)
+        .into_par_iter()
+        .flat_map(|batch_id| {
+            let mut rng = ChaCha8Rng::seed_from_u64(0);
+            rng.set_stream(batch_id as u64);
+
+            let mut batch_stats = Vec::new();
+            let start_tx_id = batch_id * tx_batch_size;
+            let end_tx_id = ((batch_id + 1) * tx_batch_size).min(tx_count);
+
+            for tx_id in start_tx_id..end_tx_id {
+                let objects = tx_generator(&mut rng);
+
+                let object_ids: Vec<usize> = objects
+                    .into_iter()
+                    .map(|obj| {
+                        *object_ids_map
+                            .entry(obj)
+                            .or_insert_with(|| next_object_id.fetch_add(1, Ordering::SeqCst))
+                    })
+                    .collect();
+
+                batch_stats.push((tx_id, object_ids));
+            }
+
+            batch_stats
+        })
+        .collect();
+
+    let num_of_distinct_objects = object_ids_map.len();
+    Some((num_of_distinct_objects, stats))
+}
+
 impl WorkloadKind {
     pub(crate) fn gas_object_num_per_account(&self) -> u64 {
         match self {
@@ -185,235 +244,27 @@ impl WorkloadKind {
         &self,
         tx_count: usize,
     ) -> Option<(usize, HashMap<usize, Vec<usize>>)> {
-        let mut rng = StdRng::seed_from_u64(0);
-
-        // TODO: Tidy these functions once we have them all.
-
         match self {
-            Self::SolanaTransactions => {
-                // Maps transaction ids to the object digests they access.
-                let mut stats = HashMap::new();
-
-                // Maps raw object digests to consecutive object ids.
-                let mut object_ids_map = HashMap::new();
-                let mut next_object_id = 0;
-
-                for tx_id in 0..tx_count {
-                    let (inputs, _) = crate::load_statistics::solana_concurrency(&mut rng);
-                    for input in &inputs {
-                        object_ids_map.entry(*input).or_insert_with(|| {
-                            let id = next_object_id;
-                            next_object_id += 1;
-                            id
-                        });
-                    }
-                    stats.insert(tx_id, inputs);
-                }
-
-                // Convert raw object digests to object ids.
-                let stats: HashMap<usize, _> = stats
-                    .into_iter()
-                    .map(|(tx_id, inputs)| {
-                        let inputs = inputs
-                            .into_iter()
-                            .map(|input| *object_ids_map.get(&input).unwrap())
-                            .collect();
-                        (tx_id, inputs)
-                    })
-                    .collect();
-
-                let num_of_distinct_objects = object_ids_map.len();
-                Some((num_of_distinct_objects, stats))
-            }
-            Self::EthereumTransfers => {
-                use std::sync::atomic::{AtomicUsize, Ordering};
-
-                use dashmap::DashMap;
-                use rand_chacha::ChaCha8Rng;
-                use rayon::prelude::*;
-                // Determine optimal batch size based on CPU cores
-                let num_threads = num_cpus::get(); // Number of available cores
-                let tx_batch_size = (tx_count / num_threads).max(10_000); // Ensure batch size is reasonable
-                let tx_batches = (tx_count + tx_batch_size - 1) / tx_batch_size; // Compute batch count
-
-                println!("Total Transactions: {}", tx_count);
-                println!("Using {} Threads", num_threads);
-                println!("Batch Size: {}", tx_batch_size);
-                println!("Total Batches: {}", tx_batches);
-
-                let object_ids_map = DashMap::new();
-                let next_object_id = AtomicUsize::new(0);
-
-                // Generate transactions in parallel
-                let stats: HashMap<usize, Vec<usize>> = (0..tx_batches)
-                    .into_par_iter()
-                    .flat_map(|batch_id| {
-                        let mut rng = ChaCha8Rng::seed_from_u64(0);
-                        rng.set_stream(batch_id as u64); // Unique deterministic RNG stream per batch
-
-                        let mut batch_stats = Vec::new();
-                        let start_tx_id = batch_id * tx_batch_size;
-                        let end_tx_id = ((batch_id + 1) * tx_batch_size).min(tx_count); // Ensure last batch doesn't exceed tx_count
-
-                        for tx_id in start_tx_id..end_tx_id {
-                            let (sender, recipient) =
-                                crate::load_statistics::ethereum_transfers(&mut rng);
-
-                            let sender_id = *object_ids_map
-                                .entry(sender)
-                                .or_insert_with(|| next_object_id.fetch_add(1, Ordering::SeqCst));
-
-                            let recipient_id = *object_ids_map
-                                .entry(recipient)
-                                .or_insert_with(|| next_object_id.fetch_add(1, Ordering::SeqCst));
-
-                            batch_stats.push((tx_id, vec![sender_id, recipient_id]));
-                        }
-
-                        batch_stats
-                    })
-                    .collect();
-                // Maps transaction ids to the object digests they access.
-                /*let mut stats = HashMap::new();
-
-                // Maps raw object digests to consecutive object ids.
-                let mut object_ids_map = HashMap::new();
-                let mut next_object_id = 0;
-
-                for tx_id in 0..tx_count {
-                    let (sender, recipient) = crate::load_statistics::ethereum_transfers(&mut rng);
-                    object_ids_map.entry(sender).or_insert_with(|| {
-                        let id = next_object_id;
-                        next_object_id += 1;
-                        id
-                    });
-                    object_ids_map.entry(recipient).or_insert_with(|| {
-                        let id = next_object_id;
-                        next_object_id += 1;
-                        id
-                    });
-                    stats.insert(tx_id, vec![sender, recipient]);
-                }
-
-                // Convert raw object digests to object ids.
-                let stats: HashMap<usize, _> = stats
-                    .into_iter()
-                    .map(|(tx_id, inputs)| {
-                        let inputs = inputs
-                            .into_iter()
-                            .map(|input| *object_ids_map.get(&input).unwrap())
-                            .collect();
-                        (tx_id, inputs)
-                    })
-                    .collect();*/
-
-                let num_of_distinct_objects = object_ids_map.len();
-                Some((num_of_distinct_objects, stats))
-            }
-            Self::EthereumNftMint => {
-                // Maps transaction ids to the object digests they access.
-                let mut stats = HashMap::new();
-
-                // Maps raw object digests to consecutive object ids.
-                let mut object_ids_map = HashMap::new();
-                let mut next_object_id = 0;
-
-                for tx_id in 0..tx_count {
-                    let (nft, minter) = crate::load_statistics::ethereum_nft_mint(&mut rng);
-                    object_ids_map.entry(nft).or_insert_with(|| {
-                        let id = next_object_id;
-                        next_object_id += 1;
-                        id
-                    });
-                    object_ids_map.entry(minter).or_insert_with(|| {
-                        let id = next_object_id;
-                        next_object_id += 1;
-                        id
-                    });
-                    stats.insert(tx_id, vec![nft, minter]);
-                }
-
-                // Convert raw object digests to object ids.
-                let stats: HashMap<usize, _> = stats
-                    .into_iter()
-                    .map(|(tx_id, inputs)| {
-                        let inputs = inputs
-                            .into_iter()
-                            .map(|input| *object_ids_map.get(&input).unwrap())
-                            .collect();
-                        (tx_id, inputs)
-                    })
-                    .collect();
-
-                let num_of_distinct_objects = object_ids_map.len();
-                Some((num_of_distinct_objects, stats))
-            }
-            Self::UniswapNormal => {
-                // Maps transaction ids to the object digests they access.
-                let mut stats = HashMap::new();
-
-                // Maps raw object digests to consecutive object ids.
-                let mut object_ids_map = HashMap::new();
-                let mut next_object_id = 0;
-
-                for tx_id in 0..tx_count {
-                    let coin_pair = crate::load_statistics::ethereum_uniswap_normal(&mut rng);
-                    object_ids_map.entry(coin_pair).or_insert_with(|| {
-                        let id = next_object_id;
-                        next_object_id += 1;
-                        id
-                    });
-                    stats.insert(tx_id, vec![coin_pair]);
-                }
-
-                // Convert raw object digests to object ids.
-                let stats: HashMap<usize, _> = stats
-                    .into_iter()
-                    .map(|(tx_id, inputs)| {
-                        let inputs = inputs
-                            .into_iter()
-                            .map(|input| *object_ids_map.get(&input).unwrap())
-                            .collect();
-                        (tx_id, inputs)
-                    })
-                    .collect();
-
-                let num_of_distinct_objects = object_ids_map.len();
-                Some((num_of_distinct_objects, stats))
-            }
-            Self::UniswapPeak => {
-                // Maps transaction ids to the object digests they access.
-                let mut stats = HashMap::new();
-
-                // Maps raw object digests to consecutive object ids.
-                let mut object_ids_map = HashMap::new();
-                let mut next_object_id = 0;
-
-                for tx_id in 0..tx_count {
-                    let coin_pair = crate::load_statistics::ethereum_uniswap_peak(&mut rng);
-                    object_ids_map.entry(coin_pair).or_insert_with(|| {
-                        let id = next_object_id;
-                        next_object_id += 1;
-                        id
-                    });
-                    stats.insert(tx_id, vec![coin_pair]);
-                }
-
-                // Convert raw object digests to object ids.
-                let stats: HashMap<usize, _> = stats
-                    .into_iter()
-                    .map(|(tx_id, inputs)| {
-                        let inputs = inputs
-                            .into_iter()
-                            .map(|input| *object_ids_map.get(&input).unwrap())
-                            .collect();
-                        (tx_id, inputs)
-                    })
-                    .collect();
-
-                let num_of_distinct_objects = object_ids_map.len();
-                Some((num_of_distinct_objects, stats))
-            }
+            Self::SolanaTransactions => build_stats_common(tx_count, |mut rng| {
+                let (inputs, _) = crate::load_statistics::solana_concurrency(&mut rng);
+                inputs
+            }),
+            Self::EthereumTransfers => build_stats_common(tx_count, |rng| {
+                let (sender, recipient) = crate::load_statistics::ethereum_transfers(rng);
+                vec![sender, recipient]
+            }),
+            Self::EthereumNftMint => build_stats_common(tx_count, |mut rng| {
+                let (nft, minter) = crate::load_statistics::ethereum_nft_mint(&mut rng);
+                vec![nft, minter]
+            }),
+            Self::UniswapNormal => build_stats_common(tx_count, |mut rng| {
+                let coin_pair = crate::load_statistics::ethereum_uniswap_normal(&mut rng);
+                vec![coin_pair]
+            }),
+            Self::UniswapPeak => build_stats_common(tx_count, |mut rng| {
+                let coin_pair = crate::load_statistics::ethereum_uniswap_peak(&mut rng);
+                vec![coin_pair]
+            }),
             WorkloadKind::NoMove
             | WorkloadKind::PTB { .. }
             | WorkloadKind::Publish { .. }

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -226,52 +226,53 @@ impl WorkloadKind {
                 Some((num_of_distinct_objects, stats))
             }
             Self::EthereumTransfers => {
-use rayon::prelude::*;
-use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
-use rand_core::RngCore;
-use dashmap::DashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
- // Determine optimal batch size based on CPU cores
-    let num_threads = num_cpus::get(); // Number of available cores
-    let tx_batch_size = (tx_count / num_threads).max(10_000); // Ensure batch size is reasonable
-    let tx_batches = (tx_count + tx_batch_size - 1) / tx_batch_size; // Compute batch count
+                use std::sync::atomic::{AtomicUsize, Ordering};
 
-    println!("Total Transactions: {}", tx_count);
-    println!("Using {} Threads", num_threads);
-    println!("Batch Size: {}", tx_batch_size);
-    println!("Total Batches: {}", tx_batches);
+                use dashmap::DashMap;
+                use rand_chacha::ChaCha8Rng;
+                use rayon::prelude::*;
+                // Determine optimal batch size based on CPU cores
+                let num_threads = num_cpus::get(); // Number of available cores
+                let tx_batch_size = (tx_count / num_threads).max(10_000); // Ensure batch size is reasonable
+                let tx_batches = (tx_count + tx_batch_size - 1) / tx_batch_size; // Compute batch count
 
-    let object_ids_map = DashMap::new();
-    let next_object_id = AtomicUsize::new(0);
+                println!("Total Transactions: {}", tx_count);
+                println!("Using {} Threads", num_threads);
+                println!("Batch Size: {}", tx_batch_size);
+                println!("Total Batches: {}", tx_batches);
 
-    // Generate transactions in parallel
-    let stats: HashMap<usize, Vec<usize>> = (0..tx_batches)
-        .into_par_iter()
-        .flat_map(|batch_id| {
-            let mut rng = ChaCha8Rng::seed_from_u64(0);
-            rng.set_stream(batch_id as u64); // Unique deterministic RNG stream per batch
+                let object_ids_map = DashMap::new();
+                let next_object_id = AtomicUsize::new(0);
 
-            let mut batch_stats = Vec::new();
-            let start_tx_id = batch_id * tx_batch_size;
-            let end_tx_id = ((batch_id + 1) * tx_batch_size).min(tx_count); // Ensure last batch doesn't exceed tx_count
+                // Generate transactions in parallel
+                let stats: HashMap<usize, Vec<usize>> = (0..tx_batches)
+                    .into_par_iter()
+                    .flat_map(|batch_id| {
+                        let mut rng = ChaCha8Rng::seed_from_u64(0);
+                        rng.set_stream(batch_id as u64); // Unique deterministic RNG stream per batch
 
-            for tx_id in start_tx_id..end_tx_id {
-                let (sender, recipient) = crate::load_statistics::ethereum_transfers(&mut rng);
+                        let mut batch_stats = Vec::new();
+                        let start_tx_id = batch_id * tx_batch_size;
+                        let end_tx_id = ((batch_id + 1) * tx_batch_size).min(tx_count); // Ensure last batch doesn't exceed tx_count
 
-                let sender_id = *object_ids_map.entry(sender).or_insert_with(|| {
-                    next_object_id.fetch_add(1, Ordering::SeqCst)
-                });
+                        for tx_id in start_tx_id..end_tx_id {
+                            let (sender, recipient) =
+                                crate::load_statistics::ethereum_transfers(&mut rng);
 
-                let recipient_id = *object_ids_map.entry(recipient).or_insert_with(|| {
-                    next_object_id.fetch_add(1, Ordering::SeqCst)
-                });
+                            let sender_id = *object_ids_map
+                                .entry(sender)
+                                .or_insert_with(|| next_object_id.fetch_add(1, Ordering::SeqCst));
 
-                batch_stats.push((tx_id, vec![sender_id, recipient_id]));
-            }
+                            let recipient_id = *object_ids_map
+                                .entry(recipient)
+                                .or_insert_with(|| next_object_id.fetch_add(1, Ordering::SeqCst));
 
-            batch_stats
-        })
-        .collect();
+                            batch_stats.push((tx_id, vec![sender_id, recipient_id]));
+                        }
+
+                        batch_stats
+                    })
+                    .collect();
                 // Maps transaction ids to the object digests they access.
                 /*let mut stats = HashMap::new();
 

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -226,8 +226,54 @@ impl WorkloadKind {
                 Some((num_of_distinct_objects, stats))
             }
             Self::EthereumTransfers => {
+use rayon::prelude::*;
+use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
+use rand_core::RngCore;
+use dashmap::DashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+ // Determine optimal batch size based on CPU cores
+    let num_threads = num_cpus::get(); // Number of available cores
+    let tx_batch_size = (tx_count / num_threads).max(10_000); // Ensure batch size is reasonable
+    let tx_batches = (tx_count + tx_batch_size - 1) / tx_batch_size; // Compute batch count
+
+    println!("Total Transactions: {}", tx_count);
+    println!("Using {} Threads", num_threads);
+    println!("Batch Size: {}", tx_batch_size);
+    println!("Total Batches: {}", tx_batches);
+
+    let object_ids_map = DashMap::new();
+    let next_object_id = AtomicUsize::new(0);
+
+    // Generate transactions in parallel
+    let stats: HashMap<usize, Vec<usize>> = (0..tx_batches)
+        .into_par_iter()
+        .flat_map(|batch_id| {
+            let mut rng = ChaCha8Rng::seed_from_u64(0);
+            rng.set_stream(batch_id as u64); // Unique deterministic RNG stream per batch
+
+            let mut batch_stats = Vec::new();
+            let start_tx_id = batch_id * tx_batch_size;
+            let end_tx_id = ((batch_id + 1) * tx_batch_size).min(tx_count); // Ensure last batch doesn't exceed tx_count
+
+            for tx_id in start_tx_id..end_tx_id {
+                let (sender, recipient) = crate::load_statistics::ethereum_transfers(&mut rng);
+
+                let sender_id = *object_ids_map.entry(sender).or_insert_with(|| {
+                    next_object_id.fetch_add(1, Ordering::SeqCst)
+                });
+
+                let recipient_id = *object_ids_map.entry(recipient).or_insert_with(|| {
+                    next_object_id.fetch_add(1, Ordering::SeqCst)
+                });
+
+                batch_stats.push((tx_id, vec![sender_id, recipient_id]));
+            }
+
+            batch_stats
+        })
+        .collect();
                 // Maps transaction ids to the object digests they access.
-                let mut stats = HashMap::new();
+                /*let mut stats = HashMap::new();
 
                 // Maps raw object digests to consecutive object ids.
                 let mut object_ids_map = HashMap::new();
@@ -258,7 +304,7 @@ impl WorkloadKind {
                             .collect();
                         (tx_id, inputs)
                     })
-                    .collect();
+                    .collect();*/
 
                 let num_of_distinct_objects = object_ids_map.len();
                 Some((num_of_distinct_objects, stats))

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -181,10 +181,10 @@ where
     let tx_batch_size = (tx_count / num_threads).max(10_000);
     let tx_batches = (tx_count + tx_batch_size - 1) / tx_batch_size;
 
-    println!("Total Transactions: {}", tx_count);
-    println!("Using {} Threads", num_threads);
-    println!("Batch Size: {}", tx_batch_size);
-    println!("Total Batches: {}", tx_batches);
+    tracing::debug!("Total Transactions: {}", tx_count);
+    tracing::debug!("Using {} Threads", num_threads);
+    tracing::debug!("Batch Size: {}", tx_batch_size);
+    tracing::debug!("Total Batches: {}", tx_batches);
 
     let object_ids_map = DashMap::new();
     let next_object_id = AtomicUsize::new(0);

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -19,13 +19,8 @@ use sui_types::{
     inner_temporary_store::InnerTemporaryStore,
     object::{Object, Owner},
     storage::{
-        get_module_by_id,
-        BackingPackageStore,
-        ChildObjectResolver,
-        GetSharedLocks,
-        ObjectStore,
-        PackageObject,
-        ParentSync,
+        get_module_by_id, BackingPackageStore, ChildObjectResolver, GetSharedLocks, ObjectStore,
+        PackageObject, ParentSync,
     },
     transaction::{InputObjectKind, InputObjects, ObjectReadResult, TransactionKey},
 };

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -9,17 +9,13 @@ use std::{
 
 use sui_core::{
     authority::{
-        authority_per_epoch_store::AuthorityPerEpochStore,
-        authority_store_tables::LiveObject,
-        test_authority_builder::TestAuthorityBuilder,
-        AuthorityState,
+        authority_per_epoch_store::AuthorityPerEpochStore, authority_store_tables::LiveObject,
+        test_authority_builder::TestAuthorityBuilder, AuthorityState,
     },
     authority_server::{ValidatorService, ValidatorServiceMetrics},
     checkpoints::checkpoint_executor::CheckpointExecutor,
     consensus_adapter::{
-        ConnectionMonitorStatusForTests,
-        ConsensusAdapter,
-        ConsensusAdapterMetrics,
+        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
     },
     state_accumulator::StateAccumulator,
     traffic_controller::metrics::TrafficControllerMetrics,
@@ -36,12 +32,8 @@ use sui_types::{
     mock_checkpoint_builder::{MockCheckpointBuilder, ValidatorKeypairProvider},
     object::Object,
     transaction::{
-        CertifiedTransaction,
-        Transaction,
-        TransactionDataAPI,
-        VerifiedCertificate,
-        VerifiedTransaction,
-        DEFAULT_VALIDATOR_GAS_PRICE,
+        CertifiedTransaction, Transaction, TransactionDataAPI, VerifiedCertificate,
+        VerifiedTransaction, DEFAULT_VALIDATOR_GAS_PRICE,
     },
 };
 use tokio::sync::broadcast;

--- a/crates/sui-single-node-benchmark/src/workload.rs
+++ b/crates/sui-single-node-benchmark/src/workload.rs
@@ -11,11 +11,8 @@ use crate::{
     command::WorkloadKind,
     tx_generator::{
         counter_tx_generator::CounterTxGenerator,
-        variable_counter_tx_generator::VariableCounterTxGenerator,
-        MoveTxGenerator,
-        NonMoveTxGenerator,
-        PackagePublishTxGenerator,
-        TxGenerator,
+        variable_counter_tx_generator::VariableCounterTxGenerator, MoveTxGenerator,
+        NonMoveTxGenerator, PackagePublishTxGenerator, TxGenerator,
     },
 };
 


### PR DESCRIPTION
## Description
1. Use rayon and chacha8rng to accelerate sampling
2. Add a unified build_stats_common fn to avoid duplication

